### PR TITLE
feat: add option to specify custom icon size

### DIFF
--- a/public/assets/icon/MessageIcon.tsx
+++ b/public/assets/icon/MessageIcon.tsx
@@ -1,0 +1,33 @@
+import React, {SVGProps} from "react";
+
+interface MessageIconProps extends SVGProps<SVGSVGElement> {
+    size?: `${number}` | number;
+    color?: string;
+}
+
+const MessageIcon = ({ 
+    size = 45, 
+    color = '#111827', 
+    ...props
+} : MessageIconProps) => {
+    return (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+            <path fillRule="evenodd" clipRule="evenodd" d="M7 10C7 9.448 7.448 9 8 9C8.552 9 9 9.448 9 10C9 10.552 8.552 11 8 11C7.448 11 7 10.552 7 10ZM12 9C11.448 9 11 9.448 11 10C11 10.552 11.448 11 12 11C12.552 11 13 10.552 13 10C13 9.448 12.552 9 12 9ZM16 9C15.448 9 15 9.448 15 10C15 10.552 15.448 11 16 11C16.552 11 17 10.552 17 10C17 9.448 16.552 9 16 9ZM20 15C20 15.551 19.551 16 19 16H8.554C8.011 16 7.477 16.148 7.01 16.428L4 18.234V5C4 4.449 4.449 4 5 4H19C19.551 4 20 4.449 20 5V15ZM19 2H5C3.346 2 2 3.346 2 5V20C2 20.36 2.194 20.693 2.507 20.87C2.66 20.957 2.83 21 3 21C3.178 21 3.356 20.953 3.515 20.857L8.039 18.143C8.195 18.049 8.373 18 8.554 18H19C20.654 18 22 16.654 22 15V5C22 3.346 20.654 2 19 2Z" fill={color}/>
+            <mask id="mask0_1_8881" style={{ maskType: 'luminance' }} maskUnits="userSpaceOnUse" x="2" y="2" width="20" height="19">
+                <path fillRule="evenodd" clipRule="evenodd" d="M7 10C7 9.448 7.448 9 8 9C8.552 9 9 9.448 9 10C9 10.552 8.552 11 8 11C7.448 11 7 10.552 7 10ZM12 9C11.448 9 11 9.448 11 10C11 10.552 11.448 11 12 11C12.552 11 13 10.552 13 10C13 9.448 12.552 9 12 9ZM16 9C15.448 9 15 9.448 15 10C15 10.552 15.448 11 16 11C16.552 11 17 10.552 17 10C17 9.448 16.552 9 16 9ZM20 15C20 15.551 19.551 16 19 16H8.554C8.011 16 7.477 16.148 7.01 16.428L4 18.234V5C4 4.449 4.449 4 5 4H19C19.551 4 20 4.449 20 5V15ZM19 2H5C3.346 2 2 3.346 2 5V20C2 20.36 2.194 20.693 2.507 20.87C2.66 20.957 2.83 21 3 21C3.178 21 3.356 20.953 3.515 20.857L8.039 18.143C8.195 18.049 8.373 18 8.554 18H19C20.654 18 22 16.654 22 15V5C22 3.346 20.654 2 19 2Z" fill="white"/>
+            </mask>
+            <g mask="url(#mask0_1_8881)">
+                <rect width="24" height="24" fill={color}/>
+            </g>
+        </svg>
+
+    );
+};
+
+export default MessageIcon;
+
+// Usage examples:
+// <MessageIcon />
+// <MessageIcon size={32} color="#3B82F6" />
+// <MessageIcon size="32" color="#3B82F6" />
+// <MessageIcon className="hover:opacity-80" />

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,5 +1,5 @@
 use clap::{Parser};
-use crate::parser::{directory_parser};
+use crate::parser::{directory_parser, size_parser};
 
 #[derive(Parser, PartialEq, Debug)]
 #[command(version)]
@@ -29,6 +29,16 @@ pub struct Args {
         value_parser = directory_parser
     )]
     pub destination: Option<String>,
+
+    /// Specify custom size of the icon you want to create, defaults to 24
+    #[
+        arg(
+            long,
+            short,
+            value_parser = size_parser
+        )
+    ]
+    pub size: Option<u32>,
 
     /// Remember the folder destination and the language for subsequent icons
     #[arg(

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -227,7 +227,7 @@ interface {}Props extends SVGProps<SVGSVGElement> {{
             r##"{}
 
 const {} = ({{ 
-    size = 24, 
+    size = {}, 
     color = '#111827', 
     ...props
 }}{}) => {{
@@ -246,6 +246,7 @@ export default {};
 "##,
             import_line,
             self.component_name,
+            self.config.size,
             props_type,
             indented_svg,
             self.component_name,

--- a/src/default.rs
+++ b/src/default.rs
@@ -8,22 +8,26 @@ use serde_json;
 pub struct Config {
     pub is_javascript: bool,
     pub destination_folder: PathBuf,
+    pub size: u32,
 }
 
 /// Get the config if it's not provided and saves it as default if specified in the argument
 pub fn get_and_save_config(args: &Args) -> Result<Config, Box<dyn std::error::Error>> {
     let config_file_path = PathBuf::from("./quickicon.json");
     let default_destination = PathBuf::from("./public/assets/icon");
+    let default_size = 24;
     
     let mut config = if config_file_path.exists() {
         serde_json::from_str(&fs::read_to_string(&config_file_path)?).unwrap_or_else(|_| Config {
             is_javascript: false,
             destination_folder: default_destination,
+            size: default_size
         })
     } else {
         Config {
             is_javascript: false,
             destination_folder: default_destination,
+            size: default_size
         }
     };
     
@@ -33,6 +37,10 @@ pub fn get_and_save_config(args: &Args) -> Result<Config, Box<dyn std::error::Er
 
     if let Some(lang) = &args.language {
         config.is_javascript = lang == "javascript";
+    }
+
+    if let Some(size) = args.size {
+        config.size = size
     }
     
     if args.default {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,6 +2,7 @@ use std::{path::PathBuf};
 
 use regex::Regex;
 
+/// Parses the directory where the icon is to be stored
 pub fn directory_parser(s: &str) -> Result<String, String> {
     match PathBuf::try_from(s) {
         Ok(_path) => {
@@ -9,6 +10,23 @@ pub fn directory_parser(s: &str) -> Result<String, String> {
         },
         Err(_) => {
             Err("Invalid icon destination".to_string())
+        }
+    }
+}
+
+/// Checks if the size is actually a valid value
+pub fn size_parser(s: &str) -> Result<u32, String> {
+    let num = s.parse::<u32>();
+    match num {
+        Ok(num) => {
+            if num > 0 {
+                return Ok(num);
+            } else {
+                return Err("The size of the icon cannot be 0".to_string());
+            }
+        },
+        Err(_) => {
+            return Err("Please enter a valid number greater than 0 for the size".to_string())
         }
     }
 }


### PR DESCRIPTION
**Summary**

- Enables users to specify custom size they want for the icon
- The size is also saved as part of the default configurations when the -D flag is passed

**Changes**
- Introduced a new flag --size or -s for short usage

**Related Issues**
Closes #1